### PR TITLE
Use CGI.unescape_html for tweets

### DIFF
--- a/bin/retrobot
+++ b/bin/retrobot
@@ -6,6 +6,7 @@ require 'csv'
 require 'pathname'
 require 'time'
 require 'optparse'
+require 'cgi'
 
 LOOP_INTERVAL = 3
 RETRY_INTERVAL = 3
@@ -82,7 +83,7 @@ def process_line(line)
     return true
   end
 
-  tweet text.gsub('@', '')
+  tweet CGI.unescape_html(text.gsub('@', ''))
   true
 rescue Twitter::Error
   logger.error "#{$!} (#{$!.class})\n  #{$@.join("\n  ")}"


### PR DESCRIPTION
Since tweet texts in tweets.csv are HTML-escaped, they should be unescaped.

ref: https://twitter.com/negipo_retro/status/408440270779207683
