### PR TITLE
add dying_message feature

### DIFF
--- a/lib/retrobot/config.rb
+++ b/lib/retrobot/config.rb
@@ -20,6 +20,7 @@ class Retrobot
       add_in_reply_to_url
       suppress_pattern
       remove_hashtag
+      dying_mention_to
     )
 
     DEFAULTS = {
@@ -34,6 +35,7 @@ class Retrobot
       add_in_reply_to_url: false,
       suppress_pattern: nil,
       remove_hashtag: false,
+      dying_mention_to: nil,
     }
 
     def initialize(options={})
@@ -59,6 +61,13 @@ class Retrobot
     def loop_interval;  @options[:loop_interval].to_i; end
     def retry_interval; @options[:retry_interval].to_i; end
     def retry_count;    @options[:retry_count].to_i; end
+
+    def dying_mention_to
+      return nil unless @options[:dying_mention_to]
+      # add mention mark (atmark)
+      @options[:dying_mention_to].start_with?('@') ?
+        @options[:dying_mention_to] : "@" + @options[:dying_mention_to]
+    end
 
     def load_yaml_file!(path)
       @options.merge! Psych.load_file(path.to_s).symbolize_keys

--- a/lib/retrobot/tweet_filters/tweet.rb
+++ b/lib/retrobot/tweet_filters/tweet.rb
@@ -12,7 +12,6 @@ class Retrobot
         tweet tweet.text
       end
 
-      private
       def tweet(text)
         logger.info "tweet: #{text}"
         return if config.dryrun

--- a/spec/lib/retrobot_spec.rb
+++ b/spec/lib/retrobot_spec.rb
@@ -88,5 +88,20 @@ describe Retrobot do
         end
       end
     end
+
+    context "no data left" do
+      before do
+        allow(retrobot).to receive(:csv).and_return([]) # empty
+      end
+
+      it 'shoud exit if no data left on starting up' do
+        expect(retrobot.init_csv).to be false
+      end
+
+      it 'should tweet a dying message and exit if no data left on tweet_loop' do
+        expect(client).to receive(:update)
+        expect(retrobot.tweet_loop).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
One year has been passed after I started to use retrobot. I have found that my retrobot was dying because there was no data on tweets.csv anymore, but I have not noticed during 3 days until @ryopeko told me as "your retrobot seems to be dying". 

This pull request is to add a feature that retrobot tells us no data is left anymore by mentioning like https://twitter.com/sonots_retro/status/561485651023912962

Users can configure `dying_mention_to` parameter to whom retrobot should mention. This dying message feature is still available even if `dying_mention_to` is not configured. In such case, the tweet should look like https://twitter.com/sonots_retro/status/561485409926922242